### PR TITLE
Remove the double quotes from the example token

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-TOKEN=thisisatoke
+TOKEN=thisisatoken
 
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-TOKEN="thisisatoke"
+TOKEN=thisisatoke
 
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa


### PR DESCRIPTION
Spring boot treats all enviroment variabled meantioned i application.properties literally so the double quotes will carry over into the token and ruin the authorization